### PR TITLE
[Automated] Update academy-theme to v0.1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,3 @@ go 1.24.5
 // replace github.com/layer5io/academy-theme v0.1.9 => ../academy-theme
 
 replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3
-
-require (
-	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.1.23 // indirect
-	github.com/twbs/bootstrap v5.3.7+incompatible // indirect
-)

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,0 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 h1:/iluJkJiyTAdnqrw3Yi9rH2HNHhrrtCmj8VJe7I6o3w=
-github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/layer5io/academy-theme v0.1.22 h1:VuK76mZFlM754M2J671Of9gwiE5k+QhyCIbnCNkrT2U=
-github.com/layer5io/academy-theme v0.1.22/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
-github.com/layer5io/academy-theme v0.1.23 h1:usS0IaPSYqZ62r5SsFbQT8gk7mlRgsGBdcTpxPoXmlE=
-github.com/layer5io/academy-theme v0.1.23/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
-github.com/twbs/bootstrap v5.3.7+incompatible h1:ea1W8TOWZFkqSK2M0McpgzLiUQVru3bz8aHb0j/XtuM=
-github.com/twbs/bootstrap v5.3.7+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.1.25.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.