### PR TITLE
fix: remove public directory in clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,7 @@ build-preview:
 
 ## Empty build cache and run on your local machine.
 clean: 
-	hugo --cleanDestinationDir
-	make site
+	rm -rf public/ resources/
 
 ## Fix Markdown linting issues
 lint-fix:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,9 @@ build-preview:
 
 ## Empty build cache and run on your local machine.
 clean: 
-	rm -rf public/ resources/
+	hugo --cleanDestinationDir
+	make setup
+	make site
 
 ## Fix Markdown linting issues
 lint-fix:


### PR DESCRIPTION
**Notes for Reviewers**

Updated the Makefile to properly remove the `public/` and `resources/` directories using `rm -rf`.

Also removed the unintended site rebuild from the clean target.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Exoscale Academy! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
