### PR TITLE
[Automated] Update academy-theme to v0.4.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.4.11 // indirect
+	github.com/layer5io/academy-theme v0.4.12 // indirect
 	github.com/twbs/bootstrap v5.3.7+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -56,5 +56,7 @@ github.com/layer5io/academy-theme v0.4.10 h1:oBt4LdFIeHCOJ/G3BYw8kEySm1Jhc/bXJYA
 github.com/layer5io/academy-theme v0.4.10/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.4.11 h1:gUnjqYRrC/LvYjIqq6UNbdgQ3XHrrs+CUdTH067ga4Q=
 github.com/layer5io/academy-theme v0.4.11/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.4.12 h1:tfw7LJ84uoqKs2DzWRaQzp85dj2uM9rJ0tRRlNFupFs=
+github.com/layer5io/academy-theme v0.4.12/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/twbs/bootstrap v5.3.7+incompatible h1:ea1W8TOWZFkqSK2M0McpgzLiUQVru3bz8aHb0j/XtuM=
 github.com/twbs/bootstrap v5.3.7+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.4.12.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.