### PR TITLE
[CI] Migrate to npm-managed local Hugo and standardise Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,30 +17,42 @@ include .github/build/Makefile.show-help.mk
 #----------------------------------------------------------------------------
 # Academy
 #----------------------------------------------------------------------------
+
 ## ------------------------------------------------------------
 ----LOCAL_BUILDS: Show help for available targets
 
-## Install site dependencies
+## Local: Install site dependencies
 setup:
-	npm install
+	npm i
 
-## Build and run site locally with draft and future content enabled.
-site: check-go
-	hugo server -D -F
-	
-## Build site for local consumption
-build:
-	hugo build
+## Verify required commands and local dependencies are present.
+check-deps:
+	@echo "Checking if 'npm' and local 'hugo' binary are present..."
+	@command -v npm > /dev/null || { echo "Error: 'npm' not found. Please install Node.js and npm."; exit 1; }
+	@test -x node_modules/.bin/hugo || { echo "Error: Hugo binary not found in node_modules. Please run 'make setup' first."; exit 1; }
+	@echo "Dependencies check passed."
 
-## Build site for local consumption
-build-preview:
-	hugo --baseURL=$(BASEURL)
+## Build site for production (no drafts, no future, no expired content).
+build: check-deps check-go
+	npm run build:production
+
+## Build site for preview with custom base URL.
+build-preview: check-deps check-go
+	npm run build:preview
+
+## Local: Build and run site locally with draft and future content enabled.
+site: check-deps check-go
+	npm run dev:site
+
+## Local: Run site locally in serve mode (without file watching).
+serve: check-deps check-go
+	npm run dev:serve
 
 ## Empty build cache and run on your local machine.
-clean: 
-	hugo --cleanDestinationDir
-	make setup
-	make site
+clean:
+	npm run clean
+	$(MAKE) setup
+	$(MAKE) site
 
 ## Fix Markdown linting issues
 lint-fix:
@@ -56,14 +68,15 @@ lint-fix:
 ## ------------------------------------------------------------
 ----MAINTENANCE: Show help for available targets
 
+## Check if Go is installed
 check-go:
 	@echo "Checking if Go is installed..."
 	@command -v go > /dev/null || (echo "Go is not installed. Please install it before proceeding."; exit 1)
 	@echo "Go is installed."
 
 ## Update the academy-theme package to latest version
-theme-update:
+theme-update: check-deps check-go
 	echo "Updating to latest academy-theme..." && \
-	hugo mod get github.com/layer5io/academy-theme
+	npm run update:theme
 
-.PHONY: setup build build-preview site clean lint-fix check-go theme-update
+.PHONY: setup check-deps check-go build build-preview site serve clean lint-fix theme-update

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Once imported, the individual Exoscale icons will be available in the Designer's
 
 Before you begin, ensure you have:
 
-- [**Hugo**](https://gohugo.io/getting-started/installing/) (extended version, recommended v0.147.9 or later)
+- [**Node.js & npm**](https://nodejs.org/) (to manage the local Hugo Extended binary)
 - [**Go**](https://go.dev/doc/install) (v1.12 or later)
 
 ## Getting Started
@@ -56,10 +56,25 @@ Before you begin, ensure you have:
    cd exoscale-academy
    ```
 
-2. **(Optional: If contributing from a fork)**
+2. **Fetch dependencies and install local Hugo**
+
+   ```bash
+   go mod tidy
+   make setup
+   ```
+
+3. **Run the local Hugo server**
+
+   ```bash
+   make site
+   ```
+
+   *(This uses the locally installed `hugo-extended` version to prevent version conflicts).*
+
+4. **(Optional: If contributing from a fork)**
    - Edit `go.mod` and update the module path to match your fork. Save and commit.
 
-3. **Organization UID**
+5. **Organization UID**
    - All Exoscale Academy content is namespaced under its Organization ID:
 
      ```
@@ -231,8 +246,14 @@ go mod tidy
 # Install necessary tools and modules
 make setup
 
+# Verify required commands and local dependencies are present
+make check-deps
+
 # Start the local Hugo development server
 make site
+
+# Run site locally in serve mode (without file watching)
+make serve
 
 # Build the site for production
 make build

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "_build": "npm run _hugo-dev --",
     "_check:links": "echo IMPLEMENTATION PENDING for check-links; echo",
     "_hugo": "hugo --cleanDestinationDir",
-    "_hugo-dev": "npm run _hugo -- -e dev -DFE",
-    "_local": "npx cross-env HUGO_MODULE_WORKSPACE=exoscale-academy.work",
+    "_hugo-dev": "hugo --cleanDestinationDir -e dev -DFE",
+    "_local": "cross-env HUGO_MODULE_WORKSPACE=exoscale-academy.work",
     "_serve": "npm run _hugo-dev -- --minify serve --renderToMemory",
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "npm run _hugo -- --minify",
@@ -22,6 +22,9 @@
     "check:links:all": "HTMLTEST_ARGS= npm run _check:links",
     "check:links": "npm run _check:links",
     "clean": "rm -Rf public/* resources",
+    "dev:build": "npm run _hugo-dev --",
+    "dev:serve": "npm run _hugo-dev -- server --watch=false",
+    "dev:site": "npm run _hugo-dev -- server",
     "local": "npm run _local -- npm run",
     "make:public": "git init -b main public",
     "precheck:links:all": "npm run build",
@@ -32,7 +35,8 @@
     "test": "npm run check:links",
     "update:dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest",
     "update:hugo": "npm install --save-dev --save-exact hugo-extended@latest",
-    "update:pkgs": "npx npm-check-updates -u"
+    "update:pkgs": "npx npm-check-updates -u",
+    "update:theme": "hugo mod get github.com/layer5io/academy-theme"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.27",


### PR DESCRIPTION
**Notes for Reviewers**

This PR migrates the `exoscale-academy` build process to use an npm-managed local Hugo dependency, standardizing the local development experience and mitigating version mismatch issues. 

Specific updates include:
* Adding a `check-deps` target to the `Makefile` to validate `npm` and the local `hugo` binary.
* Rerouting `site`, `serve`, `build`, and `clean` commands to trigger `npm run` scripts.
* Adding `dev:*` scripts to `package.json` to handle Hugo commands with the correct flags, stripping out unnecessary `npx` prefixes.
* Updating `README.md` to remove references to a globally installed Hugo and emphasize the new `make setup` -> `make site` workflow.

This PR fixes #407

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.