### PR TITLE
[Curriculum] Fix broken relative links in workshop overview pages

### DIFF
--- a/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-CKA-Preparation/_index.md
+++ b/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-CKA-Preparation/_index.md
@@ -10,63 +10,63 @@ no_list: true
 banner: "kubernetes-icon.svg"
 ---
 
-Welcome to this hands-on workshop where you'll prepare for the **Certified Kubernetes Administrator** (CKA) certification. This workshop is organized into the following sections, which you can access directly by clicking on the corresponding card. If you want to get the most out of this preparation, follow the sections in order, starting with the presentation of the [Kubernetes certifications](./1.certifications).
+Welcome to this hands-on workshop where you'll prepare for the **Certified Kubernetes Administrator** (CKA) certification. This workshop is organized into the following sections, which you can access directly by clicking on the corresponding card. If you want to get the most out of this preparation, follow the sections in order, starting with the presentation of the [Kubernetes certifications]({{< relref "1.certifications" >}}).
 
 {{< hextra/cards >}}
     {{< hextra/card    title="Certifications" 
                 subtitle="Get an overview of the existing Kubernetes certifications and what you need to learn for the CKA."
                 icon="kubernetes"
-                link="./1.certifications"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-cka-preparation/1.certifications/"
     >}}
     {{< hextra/card    title="Create a cluster" 
                 subtitle="Build a 3-node kubeadm cluster from scratch."
                 icon="kubernetes"
-                link="./2.creation"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-cka-preparation/2.creation/"
     >}}
     {{< hextra/card    title="Workloads" 
                 subtitle="Create and manage Pods, Deployments, and other workload resources." 
                 icon="pod"
-                link="./3.workload"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-cka-preparation/3.workload/"
     >}}
     {{< hextra/card    title="Scheduling Pods"
                 subtitle="Learn Pod placement strategies using labels, taints, affinities and more." 
                 icon="pod"
-                link="./4.scheduling"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-cka-preparation/4.scheduling/"
     >}}
     {{< hextra/card    title="Networking" 
                 subtitle="Understand Pod to Pod communication, Service discovery, Ingress resources." 
                 icon="service"
-                link="./5.networking"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-cka-preparation/5.networking/"
     >}}
     {{< hextra/card    title="Storage" 
                 subtitle="Understand StorageClass, PV and PVCs stateful applications."
                 icon="pvc"
-                link="./6.storage"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-cka-preparation/6.storage/"
     >}}
     {{< hextra/card    title="Security" 
                 subtitle="Create Network Policies and RBAC rules."
                 icon="pvc"
-                link="./7.security"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-cka-preparation/7.security/"
     >}}
     {{< hextra/card    title="Configuration" 
                 subtitle="Tools to manage complex applciations."
                 icon="pvc"
-                link="./8.configuration"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-cka-preparation/8.configuration/"
     >}}
     {{< hextra/card    title="Troubleshooting" 
                 subtitle="Troubleshoot clusters components, nodes, network and applications." 
                 icon="terminal"
-                link="./9.troubleshooting"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-cka-preparation/9.troubleshooting/"
     >}}
     {{< hextra/card    title="Operations" 
                 subtitle="Perform cluster upgrade and backup/restore of etcd." 
                 icon="terminal"
-                link="./10.operations"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-cka-preparation/10.operations/"
     >}}
     {{< hextra/card    title="Challenges" 
                 subtitle="Break your cluster and try to fix it." 
                 icon="terminal"
-                link="./11.challenges"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-cka-preparation/11.challenges/"
     >}}
 {{< /hextra/cards >}}
 

--- a/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-Exoscale-introduction/_index.md
+++ b/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-Exoscale-introduction/_index.md
@@ -10,47 +10,47 @@ no_list: true
 banner: "exoscale-icon.svg"
 ---
 
-Welcome to this hands-on workshop where you'll learn to deploy a microservice application in Kubernetes using Exoscale's platform and open-source tools. This workshop provides detailed instructions and explanations to explore Exoscale's offering. It is organized into the following sections, each building upon the previous one. You can access a section directly by clicking on the corresponding card, but if you want to get the most out of this workshop it's recommended you follow the section in order, starting with the presentation of the [VotingApp](./votingapp).
+Welcome to this hands-on workshop where you'll learn to deploy a microservice application in Kubernetes using Exoscale's platform and open-source tools. This workshop provides detailed instructions and explanations to explore Exoscale's offering. It is organized into the following sections, each building upon the previous one. You can access a section directly by clicking on the corresponding card, but if you want to get the most out of this workshop it's recommended you follow the section in order, starting with the presentation of the [VotingApp]({{< relref "1.votingapp" >}}).
 
 {{< hextra/cards >}}
     {{< hextra/card    title="What is the VotingApp?" 
                 subtitle="Introduction to our sample application"
                 icon="votingapp"
-                link="./1.votingapp"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-exoscale-introduction/1.votingapp/"
     >}}
     {{< hextra/card    title="Deploying the VotingApp" 
                 subtitle="Launch the application in an Exoscale-managed cluster"
                 icon="exo-sks"
-                link="./2.sks"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-exoscale-introduction/2.sks/"
     >}}
     {{< hextra/card    title="Exposing the VotingApp" 
                 subtitle="Use Network Load Balancer to expose the application" 
                 icon="exo-nlb"
-                link="./3.nlb"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-exoscale-introduction/3.nlb/"
     >}}
     {{< hextra/card    title="Configuring DNS" 
                 subtitle="Expose the application on its own domain" 
                 icon="exo-dns"
-                link="./4.dns"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-exoscale-introduction/4.dns/"
     >}}
     {{< hextra/card    title="Activating TLS" 
                 subtitle="Automate certificate management with cert-manager"
                 icon="cert-manager"
-                link="./5.tls"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-exoscale-introduction/5.tls/"
     >}}
     {{< hextra/card    title="Managing Secrets" 
                 subtitle="Secure sensitive information with HashiCorp Vault"
                 icon="vault"
-                link="./6.vault"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-exoscale-introduction/6.vault/"
     >}}
     {{< hextra/card    title="Persisting data in DBaaS" 
                 subtitle="Store application data in Exoscale-managed databases"
                 icon="exo-dbaas"
-                link="./7.dbaas"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-exoscale-introduction/7.dbaas/"
     >}}
     {{< hextra/card    title="Using Object Storage" 
                 subtitle="Store application assets in Object Storage"
                 icon="exo-sos"
-                link="./8.sos"
+                link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-exoscale-introduction/8.sos/"
     >}}
 {{< /hextra/cards >}}

--- a/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-K8S-introduction/_index.md
+++ b/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-K8S-introduction/_index.md
@@ -9,41 +9,41 @@ no_list: true
 banner: "kubernetes-icon.svg"
 ---
 
-Welcome to this hands-on workshop where you'll learn the basics of Kubernetes by deploying a microservice application. It is organized into the following sections, each building upon the previous one. You can access a section directly by clicking on the corresponding card, but if you want to get the most out of this workshop it's recommended you follow the section in order, starting with the presentation of the [VotingApp](./1.votingapp).
+Welcome to this hands-on workshop where you'll learn the basics of Kubernetes by deploying a microservice application. It is organized into the following sections, each building upon the previous one. You can access a section directly by clicking on the corresponding card, but if you want to get the most out of this workshop it's recommended you follow the section in order, starting with the presentation of the [VotingApp]({{< relref "1.votingapp" >}}).
 
 
 {{< hextra/cards >}}
-    {{< hextra/card    link="./1.votingapp" 
+    {{< hextra/card    link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-k8s-introduction/1.votingapp/" 
                 title="The VotingApp" 
                 subtitle="Introducing our toy application" 
                 icon="votingapp"
     >}}
-    {{< hextra/card    link="./2.concepts" 
+    {{< hextra/card    link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-k8s-introduction/2.concepts/" 
                 title="Concepts" 
                 subtitle="Kubernetes main concepts" 
                 icon="book-open"
     >}}
-    {{< hextra/card    link="./3.local" 
+    {{< hextra/card    link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-k8s-introduction/3.local/" 
                 title="Local cluster" 
                 subtitle="Create a local Kubernetes cluster" 
                 icon="kubernetes"
     >}}
-    {{< hextra/card    link="./4.resources" 
+    {{< hextra/card    link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-k8s-introduction/4.resources/" 
                 title="Main resources" 
                 subtitle="Concepts, exercises, and solutions for main resources" 
                 icon="code"
     >}}
-    {{< hextra/card    link="./5.troubleshooting" 
+    {{< hextra/card    link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-k8s-introduction/5.troubleshooting/" 
                 title="Troubleshooting" 
                 subtitle="Common issues and remediation" 
                 icon="term"
     >}}
-    {{< hextra/card    link="./6.ecosystem" 
+    {{< hextra/card    link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-k8s-introduction/6.ecosystem/" 
                 title="Ecosystem" 
                 subtitle="Useful tools and projects from the Kubernetes ecosystem" 
                 icon="globe"
     >}}
-    {{< hextra/card    link="./7.next" 
+    {{< hextra/card    link="/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/workshop-k8s-introduction/7.next/" 
                 title="Next steps" 
                 subtitle="Suggestions to bring your cluster to the next level." 
                 icon="arrow-circle-right"


### PR DESCRIPTION
**Notes for Reviewers**
- Replaced relative links (`./`) in the overview cards of the three learning path workshops (CKA Preparation, Exoscale Introduction, and Kubernetes Introduction) with root-relative paths.
- Replaced inline text links pointing to the first sections with Hugo's `{{< relref >}}` shortcode.
- Verified that the site builds successfully and the links resolve correctly even when accessing the overview page URLs without a trailing slash.

This PR fixes #414 




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Exoscale Academy! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
