### PR TITLE
feat: adopt theme-level slack-invite shortcode, drop org-UUID namespace

### DIFF
--- a/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-CKA-Preparation/_index.md
+++ b/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-CKA-Preparation/_index.md
@@ -70,4 +70,4 @@ Welcome to this hands-on workshop where you'll prepare for the **Certified Kuber
     >}}
 {{< /hextra/cards >}}
 
-{{< 1e2a8e46-937c-47ea-ab43-5716e3bcab2e/slack-invite link="https://join.slack.com/t/exoscale-org/shared_invite/zt-34s6jetvl-tNP_TpfweeAKNnPb593j9A">}}
+{{< slack-invite link="https://join.slack.com/t/exoscale-org/shared_invite/zt-34s6jetvl-tNP_TpfweeAKNnPb593j9A">}}

--- a/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-K8S-introduction/_index.md
+++ b/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-K8S-introduction/_index.md
@@ -50,4 +50,4 @@ Welcome to this hands-on workshop where you'll learn the basics of Kubernetes by
     >}}
 {{< /hextra/cards >}}
 
-{{< 1e2a8e46-937c-47ea-ab43-5716e3bcab2e/slack-invite link="https://join.slack.com/t/exoscale-org/shared_invite/zt-34s6jetvl-tNP_TpfweeAKNnPb593j9A">}}
+{{< slack-invite link="https://join.slack.com/t/exoscale-org/shared_invite/zt-34s6jetvl-tNP_TpfweeAKNnPb593j9A">}}

--- a/layouts/shortcodes/slack-invite.html
+++ b/layouts/shortcodes/slack-invite.html
@@ -1,0 +1,11 @@
+{{- $link := .Get "link" -}}
+<div style="background-color: #F8F8F8; border: 1px solid #DDD; border-radius: 12px; padding: 24px; max-width: 600px; margin: 2rem auto; box-shadow: 0 2px 6px rgba(0,0,0,0.05); font-family: system-ui, sans-serif; text-align: center;">
+    <h2 style="margin-top: 0; color: #4A154B; font-size: 1.5rem;">💬 Join Our Slack Community</h2>
+    <p style="margin-bottom: 1rem; font-size: 1rem; line-height: 1.5; color: #333;">
+      Got questions about the workshop? Looking for help or want to share your tips & tricks?
+      You're welcome to join our Slack workspace and connect with other participants.
+    </p>
+    <a href="{{ $link | safeURL }}" target="_blank" rel="noopener" style="text-decoration: none; display: inline-block; margin-top: 0.5rem; background-color: #4A154B; color: white; padding: 12px 24px; border-radius: 8px; font-size: 16px; cursor: pointer;">
+      🚀 Join the Slack Community
+    </a>
+</div>


### PR DESCRIPTION
## Summary

- Replaces the two org-UUID-namespaced `slack-invite` shortcode calls with the generic theme-level form
- Adds a local `layouts/shortcodes/slack-invite.html` bridge so the site builds correctly until [academy-theme#215](https://github.com/layer5io/academy-theme/pull/215) is merged and `go.mod` is bumped

### Before
```
{{< 1e2a8e46-937c-47ea-ab43-5716e3bcab2e/slack-invite link="..." >}}
```

### After
```
{{< slack-invite link="..." >}}
```

## Context

Follows up the discussion in PR #416, where it was noted that the org UUID (`1e2a8e46-...`) was hardcoded in shortcode calls. The `academy-theme` now ships two new shortcodes:

- `org-id` — dynamically extracts the org UUID from the current page's path (`learning-paths/{orgID}/...`)
- `slack-invite` — generic Slack invite card, no longer org-namespaced

See: https://github.com/layer5io/academy-theme/pull/215

## Follow-on

Once the theme PR is merged and the version is bumped in `go.mod`, the local `layouts/shortcodes/slack-invite.html` can be removed. The now-unused `layouts/shortcodes/1e2a8e46-.../slack-invite.html` org override can also be cleaned up.

## Test plan
- [ ] `hugo server` builds without shortcode errors
- [ ] Slack invite card renders correctly on Workshop CKA and Workshop K8S overview pages

---
_Generated by [Claude Code](https://claude.ai/code/session_01JT6MYs3QBMYVi2hj2zPLN6)_