### PR TITLE
content: use org-id shortcode in Workshop Exoscale Intro learning path

### DIFF
--- a/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-Exoscale-introduction/_index.md
+++ b/content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-Exoscale-introduction/_index.md
@@ -10,6 +10,8 @@ no_list: true
 banner: "exoscale-icon.svg"
 ---
 
+**Organization ID:** {{< org-id >}}
+
 Welcome to this hands-on workshop where you'll learn to deploy a microservice application in Kubernetes using Exoscale's platform and open-source tools. This workshop provides detailed instructions and explanations to explore Exoscale's offering. It is organized into the following sections, each building upon the previous one. You can access a section directly by clicking on the corresponding card, but if you want to get the most out of this workshop it's recommended you follow the section in order, starting with the presentation of the [VotingApp]({{< relref "1.votingapp" >}}).
 
 {{< hextra/cards >}}


### PR DESCRIPTION
## Summary

- Incorporates the new `org-id` shortcode (introduced in `layer5io/academy-theme`) into the Workshop Exoscale Intro learning path index page
- Adds `**Organization ID:** {{< org-id >}}` to `content/learning-paths/1e2a8e46-937c-47ea-ab43-5716e3bcab2e/Workshop-Exoscale-introduction/_index.md`
- The shortcode extracts and renders the org UUID (`1e2a8e46-937c-47ea-ab43-5716e3bcab2e`) from the content path

## Test plan

- [ ] Verify the Organization ID line renders correctly on the Workshop Exoscale Intro page
- [ ] Confirm the UUID displayed matches `1e2a8e46-937c-47ea-ab43-5716e3bcab2e`