### PR TITLE
Revert "[Content]: "Instructor Toolkit" Integration"

### DIFF
--- a/content/instructor-toolkit/_index.md
+++ b/content/instructor-toolkit/_index.md
@@ -1,6 +1,0 @@
----
-title: "Instructor Toolkit"
-draft: false
----
-
-{{< instructor-toolkit >}}


### PR DESCRIPTION
Reverts layer5io/exoscale-academy#420

@banana-three-join, I looked at the PR too quickly, thinking this was the meshery-academy repo.

I'm reverting this PR, because this repo already has the Instructors Toolkit in it, no?