### PR TITLE
Revert "[CI] Migrate to npm-managed local Hugo and standardise Makefile targets"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,42 +17,30 @@ include .github/build/Makefile.show-help.mk
 #----------------------------------------------------------------------------
 # Academy
 #----------------------------------------------------------------------------
-
 ## ------------------------------------------------------------
 ----LOCAL_BUILDS: Show help for available targets
 
-## Local: Install site dependencies
+## Install site dependencies
 setup:
-	npm i
+	npm install
 
-## Verify required commands and local dependencies are present.
-check-deps:
-	@echo "Checking if 'npm' and local 'hugo' binary are present..."
-	@command -v npm > /dev/null || { echo "Error: 'npm' not found. Please install Node.js and npm."; exit 1; }
-	@test -x node_modules/.bin/hugo || { echo "Error: Hugo binary not found in node_modules. Please run 'make setup' first."; exit 1; }
-	@echo "Dependencies check passed."
+## Build and run site locally with draft and future content enabled.
+site: check-go
+	hugo server -D -F
+	
+## Build site for local consumption
+build:
+	hugo build
 
-## Build site for production (no drafts, no future, no expired content).
-build: check-deps check-go
-	npm run build:production
-
-## Build site for preview with custom base URL.
-build-preview: check-deps check-go
-	npm run build:preview
-
-## Local: Build and run site locally with draft and future content enabled.
-site: check-deps check-go
-	npm run dev:site
-
-## Local: Run site locally in serve mode (without file watching).
-serve: check-deps check-go
-	npm run dev:serve
+## Build site for local consumption
+build-preview:
+	hugo --baseURL=$(BASEURL)
 
 ## Empty build cache and run on your local machine.
-clean:
-	npm run clean
-	$(MAKE) setup
-	$(MAKE) site
+clean: 
+	hugo --cleanDestinationDir
+	make setup
+	make site
 
 ## Fix Markdown linting issues
 lint-fix:
@@ -68,15 +56,14 @@ lint-fix:
 ## ------------------------------------------------------------
 ----MAINTENANCE: Show help for available targets
 
-## Check if Go is installed
 check-go:
 	@echo "Checking if Go is installed..."
 	@command -v go > /dev/null || (echo "Go is not installed. Please install it before proceeding."; exit 1)
 	@echo "Go is installed."
 
 ## Update the academy-theme package to latest version
-theme-update: check-deps check-go
+theme-update:
 	echo "Updating to latest academy-theme..." && \
-	npm run update:theme
+	hugo mod get github.com/layer5io/academy-theme
 
-.PHONY: setup check-deps check-go build build-preview site serve clean lint-fix theme-update
+.PHONY: setup build build-preview site clean lint-fix check-go theme-update

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Once imported, the individual Exoscale icons will be available in the Designer's
 
 Before you begin, ensure you have:
 
-- [**Node.js & npm**](https://nodejs.org/) (to manage the local Hugo Extended binary)
+- [**Hugo**](https://gohugo.io/getting-started/installing/) (extended version, recommended v0.147.9 or later)
 - [**Go**](https://go.dev/doc/install) (v1.12 or later)
 
 ## Getting Started
@@ -58,25 +58,10 @@ Before you begin, ensure you have:
    cd exoscale-academy
    ```
 
-2. **Fetch dependencies and install local Hugo**
-
-   ```bash
-   go mod tidy
-   make setup
-   ```
-
-3. **Run the local Hugo server**
-
-   ```bash
-   make site
-   ```
-
-   *(This uses the locally installed `hugo-extended` version to prevent version conflicts).*
-
-4. **(Optional: If contributing from a fork)**
+2. **(Optional: If contributing from a fork)**
    - Edit `go.mod` and update the module path to match your fork. Save and commit.
 
-5. **Organization UID**
+3. **Organization UID**
    - All Exoscale Academy content is namespaced under its Organization ID:
 
      ```
@@ -248,14 +233,8 @@ go mod tidy
 # Install necessary tools and modules
 make setup
 
-# Verify required commands and local dependencies are present
-make check-deps
-
 # Start the local Hugo development server
 make site
-
-# Run site locally in serve mode (without file watching)
-make serve
 
 # Build the site for production
 make build

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "_build": "npm run _hugo-dev --",
     "_check:links": "echo IMPLEMENTATION PENDING for check-links; echo",
     "_hugo": "hugo --cleanDestinationDir",
-    "_hugo-dev": "hugo --cleanDestinationDir -e dev -DFE",
-    "_local": "cross-env HUGO_MODULE_WORKSPACE=exoscale-academy.work",
+    "_hugo-dev": "npm run _hugo -- -e dev -DFE",
+    "_local": "npx cross-env HUGO_MODULE_WORKSPACE=exoscale-academy.work",
     "_serve": "npm run _hugo-dev -- --minify serve --renderToMemory",
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "npm run _hugo -- --minify",
@@ -22,9 +22,6 @@
     "check:links:all": "HTMLTEST_ARGS= npm run _check:links",
     "check:links": "npm run _check:links",
     "clean": "rm -Rf public/* resources",
-    "dev:build": "npm run _hugo-dev --",
-    "dev:serve": "npm run _hugo-dev -- server --watch=false",
-    "dev:site": "npm run _hugo-dev -- server",
     "local": "npm run _local -- npm run",
     "make:public": "git init -b main public",
     "precheck:links:all": "npm run build",
@@ -35,8 +32,7 @@
     "test": "npm run check:links",
     "update:dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest",
     "update:hugo": "npm install --save-dev --save-exact hugo-extended@latest",
-    "update:pkgs": "npx npm-check-updates -u",
-    "update:theme": "hugo mod get github.com/layer5io/academy-theme"
+    "update:pkgs": "npx npm-check-updates -u"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.27",


### PR DESCRIPTION
"Reverts layer5io/exoscale-academy#408"

The merging of this PR is currently causing issues with the upstream [github action](https://github.com/layer5io/academy-theme/actions/runs/28129259201) which unables an automatic bump in version whenever a new release of the parent theme is released. 